### PR TITLE
[FLINK-37230] Consolidate Table options

### DIFF
--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduCommonOptions.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduCommonOptions.java
@@ -25,8 +25,8 @@ import org.apache.flink.configuration.ConfigOptions;
 @PublicEvolving
 public class KuduCommonOptions {
 
-    public static final ConfigOption<String> KUDU_MASTERS =
-            ConfigOptions.key("kudu.masters")
+    public static final ConfigOption<String> MASTERS =
+            ConfigOptions.key("masters")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("kudu's master server address");

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactory.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactory.java
@@ -39,20 +39,20 @@ import javax.annotation.Nullable;
 
 import java.util.Set;
 
-import static org.apache.flink.connector.kudu.table.KuduCommonOptions.KUDU_MASTERS;
+import static org.apache.flink.connector.kudu.table.KuduCommonOptions.MASTERS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.FLUSH_INTERVAL;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.FLUSH_MODE;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH_COLS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH_PARTITION_NUMS;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.IDENTIFIER;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_FLUSH_INTERVAL;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_FLUSH_MODE;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_HASH_COLS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_HASH_PARTITION_NUMS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_IGNORE_DUPLICATE;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_IGNORE_NOT_FOUND;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_MAX_BUFFER_SIZE;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_OPERATION_TIMEOUT;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_PRIMARY_KEY_COLS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_REPLICAS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_SCAN_ROW_SIZE;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_TABLE;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.IGNORE_DUPLICATE;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.IGNORE_NOT_FOUND;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.MAX_BUFFER_SIZE;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.OPERATION_TIMEOUT;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.PRIMARY_KEY_COLS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.REPLICAS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.SCAN_ROW_SIZE;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.TABLE_NAME;
 
 /**
  * Factory for creating configured instances of {@link KuduDynamicTableSource}/{@link
@@ -67,25 +67,24 @@ public class KuduDynamicTableFactory implements DynamicTableSourceFactory, Dynam
 
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
-        return Sets.newHashSet(KUDU_MASTERS);
+        return Sets.newHashSet(MASTERS);
     }
 
     @Override
     public Set<ConfigOption<?>> optionalOptions() {
         return Sets.newHashSet(
-                KUDU_TABLE,
-                KUDU_HASH_COLS,
-                KUDU_HASH_PARTITION_NUMS,
-                KUDU_PRIMARY_KEY_COLS,
-                KUDU_SCAN_ROW_SIZE,
-                KUDU_REPLICAS,
-                KUDU_MAX_BUFFER_SIZE,
-                KUDU_MAX_BUFFER_SIZE,
-                KUDU_OPERATION_TIMEOUT,
-                KUDU_FLUSH_MODE,
-                KUDU_FLUSH_INTERVAL,
-                KUDU_IGNORE_NOT_FOUND,
-                KUDU_IGNORE_DUPLICATE,
+                TABLE_NAME,
+                HASH_COLS,
+                HASH_PARTITION_NUMS,
+                PRIMARY_KEY_COLS,
+                SCAN_ROW_SIZE,
+                REPLICAS,
+                MAX_BUFFER_SIZE,
+                OPERATION_TIMEOUT,
+                FLUSH_MODE,
+                FLUSH_INTERVAL,
+                IGNORE_NOT_FOUND,
+                IGNORE_DUPLICATE,
                 LookupOptions.CACHE_TYPE,
                 LookupOptions.PARTIAL_CACHE_MAX_ROWS,
                 LookupOptions.PARTIAL_CACHE_EXPIRE_AFTER_ACCESS,
@@ -99,7 +98,7 @@ public class KuduDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         final ReadableConfig config = getValidatedConfig(context);
 
         final String tableName =
-                config.getOptional(KUDU_TABLE)
+                config.getOptional(TABLE_NAME)
                         .orElse(context.getObjectIdentifier().getObjectName());
         final ResolvedSchema schema = context.getCatalogTable().getResolvedSchema();
         final KuduTableInfo tableInfo =
@@ -107,13 +106,13 @@ public class KuduDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                         tableName, schema, context.getCatalogTable().toProperties());
 
         final KuduWriterConfig.Builder configBuilder =
-                KuduWriterConfig.Builder.setMasters(config.get(KUDU_MASTERS))
-                        .setOperationTimeout(config.get(KUDU_OPERATION_TIMEOUT).toMillis())
-                        .setConsistency(config.get(KUDU_FLUSH_MODE))
-                        .setFlushInterval((int) config.get(KUDU_FLUSH_INTERVAL).toMillis())
-                        .setMaxBufferSize(config.get(KUDU_MAX_BUFFER_SIZE))
-                        .setIgnoreNotFound(config.get(KUDU_IGNORE_NOT_FOUND))
-                        .setIgnoreDuplicate(config.get(KUDU_IGNORE_DUPLICATE));
+                KuduWriterConfig.Builder.setMasters(config.get(MASTERS))
+                        .setOperationTimeout(config.get(OPERATION_TIMEOUT).toMillis())
+                        .setConsistency(config.get(FLUSH_MODE))
+                        .setFlushInterval((int) config.get(FLUSH_INTERVAL).toMillis())
+                        .setMaxBufferSize(config.get(MAX_BUFFER_SIZE))
+                        .setIgnoreNotFound(config.get(IGNORE_NOT_FOUND))
+                        .setIgnoreDuplicate(config.get(IGNORE_DUPLICATE));
 
         return new KuduDynamicTableSink(configBuilder, tableInfo, schema);
     }
@@ -123,7 +122,7 @@ public class KuduDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         final ReadableConfig config = getValidatedConfig(context);
 
         final String tableName =
-                config.getOptional(KUDU_TABLE)
+                config.getOptional(TABLE_NAME)
                         .orElse(context.getObjectIdentifier().getObjectName());
         final KuduTableInfo tableInfo =
                 KuduTableUtils.createTableInfo(
@@ -132,8 +131,8 @@ public class KuduDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                         context.getCatalogTable().toProperties());
 
         final KuduReaderConfig.Builder readerConfigBuilder =
-                KuduReaderConfig.Builder.setMasters(config.get(KUDU_MASTERS))
-                        .setRowLimit(config.get(KUDU_SCAN_ROW_SIZE));
+                KuduReaderConfig.Builder.setMasters(config.get(MASTERS))
+                        .setRowLimit(config.get(SCAN_ROW_SIZE));
 
         return new KuduDynamicTableSource(
                 readerConfigBuilder,

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableOptions.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableOptions.java
@@ -31,75 +31,83 @@ public class KuduDynamicTableOptions {
 
     public static final String IDENTIFIER = "kudu";
 
-    public static final ConfigOption<String> KUDU_TABLE =
-            ConfigOptions.key("kudu.table")
+    public static final ConfigOption<String> TABLE_NAME =
+            ConfigOptions.key("table-name")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("kudu's table name");
 
-    public static final ConfigOption<String> KUDU_HASH_COLS =
-            ConfigOptions.key("kudu.hash-columns")
+    public static final ConfigOption<String> HASH_COLS =
+            ConfigOptions.key("hash-columns")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("kudu's hash columns");
 
-    public static final ConfigOption<Integer> KUDU_REPLICAS =
-            ConfigOptions.key("kudu.replicas")
-                    .intType()
-                    .defaultValue(3)
-                    .withDescription("kudu's replica nums");
-
-    public static final ConfigOption<Integer> KUDU_MAX_BUFFER_SIZE =
-            ConfigOptions.key("kudu.max-buffer-size")
-                    .intType()
-                    .defaultValue(1000)
-                    .withDescription("kudu's max buffer size");
-
-    public static final ConfigOption<SessionConfiguration.FlushMode> KUDU_FLUSH_MODE =
-            ConfigOptions.key("kudu.flush-mode")
-                    .enumType(SessionConfiguration.FlushMode.class)
-                    .defaultValue(SessionConfiguration.FlushMode.AUTO_FLUSH_BACKGROUND)
-                    .withDescription("kudu's data flush mode");
-
-    public static final ConfigOption<Duration> KUDU_FLUSH_INTERVAL =
-            ConfigOptions.key("kudu.flush-interval")
-                    .durationType()
-                    .defaultValue(Duration.ofMillis(1000))
-                    .withDescription("kudu's data flush interval");
-
-    public static final ConfigOption<Duration> KUDU_OPERATION_TIMEOUT =
-            ConfigOptions.key("kudu.operation-timeout")
-                    .durationType()
-                    .defaultValue(Duration.ofSeconds(30))
-                    .withDescription("kudu's operation timeout");
-
-    public static final ConfigOption<Boolean> KUDU_IGNORE_NOT_FOUND =
-            ConfigOptions.key("kudu.ignore-not-found")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription("if true, ignore all not found rows");
-
-    public static final ConfigOption<Boolean> KUDU_IGNORE_DUPLICATE =
-            ConfigOptions.key("kudu.ignore-duplicate")
-                    .booleanType()
-                    .defaultValue(false)
-                    .withDescription("if true, ignore all duplicate rows");
-
-    public static final ConfigOption<Integer> KUDU_HASH_PARTITION_NUMS =
-            ConfigOptions.key("kudu.hash-partition-nums")
-                    .intType()
-                    .defaultValue(KUDU_REPLICAS.defaultValue() * 2)
-                    .withDescription(
-                            "kudu's hash partition bucket nums, defaultValue is 2 * replica nums");
-
-    public static final ConfigOption<String> KUDU_PRIMARY_KEY_COLS =
-            ConfigOptions.key("kudu.primary-key-columns")
+    public static final ConfigOption<String> PRIMARY_KEY_COLS =
+            ConfigOptions.key("primary-key-columns")
                     .stringType()
                     .noDefaultValue()
                     .withDescription("kudu's primary key, primary key must be ordered");
 
-    public static final ConfigOption<Integer> KUDU_SCAN_ROW_SIZE =
-            ConfigOptions.key("kudu.scan.row-size")
+    public static final ConfigOption<Integer> REPLICAS =
+            ConfigOptions.key("replicas")
+                    .intType()
+                    .defaultValue(3)
+                    .withDescription("kudu's replica nums");
+
+    public static final ConfigOption<Integer> HASH_PARTITION_NUMS =
+            ConfigOptions.key("hash-partition-nums")
+                    .intType()
+                    .defaultValue(REPLICAS.defaultValue() * 2)
+                    .withDescription(
+                            "kudu's hash partition bucket nums, defaultValue is 2 * replicas");
+
+    // -----------------------------------------------------------------------------------------
+    // Sink options
+    // -----------------------------------------------------------------------------------------
+
+    public static final ConfigOption<Integer> MAX_BUFFER_SIZE =
+            ConfigOptions.key("sink.max-buffer-size")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDescription("kudu's max buffer size");
+
+    public static final ConfigOption<SessionConfiguration.FlushMode> FLUSH_MODE =
+            ConfigOptions.key("sink.flush-mode")
+                    .enumType(SessionConfiguration.FlushMode.class)
+                    .defaultValue(SessionConfiguration.FlushMode.AUTO_FLUSH_BACKGROUND)
+                    .withDescription("kudu's data flush mode");
+
+    public static final ConfigOption<Duration> FLUSH_INTERVAL =
+            ConfigOptions.key("sink.flush-interval")
+                    .durationType()
+                    .defaultValue(Duration.ofMillis(1000))
+                    .withDescription("kudu's data flush interval");
+
+    public static final ConfigOption<Duration> OPERATION_TIMEOUT =
+            ConfigOptions.key("sink.operation-timeout")
+                    .durationType()
+                    .defaultValue(Duration.ofSeconds(30))
+                    .withDescription("kudu's operation timeout");
+
+    public static final ConfigOption<Boolean> IGNORE_NOT_FOUND =
+            ConfigOptions.key("sink.ignore-not-found")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("if true, ignore all not found rows");
+
+    public static final ConfigOption<Boolean> IGNORE_DUPLICATE =
+            ConfigOptions.key("sink.ignore-duplicate")
+                    .booleanType()
+                    .defaultValue(false)
+                    .withDescription("if true, ignore all duplicate rows");
+
+    // -----------------------------------------------------------------------------------------
+    // Scan options
+    // -----------------------------------------------------------------------------------------
+
+    public static final ConfigOption<Integer> SCAN_ROW_SIZE =
+            ConfigOptions.key("scan.row-size")
                     .intType()
                     .defaultValue(0)
                     .withDescription("kudu's scan row size");

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/catalog/KuduCatalog.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/catalog/KuduCatalog.java
@@ -62,12 +62,12 @@ import java.util.Optional;
 import java.util.Set;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.connector.kudu.table.KuduCommonOptions.KUDU_MASTERS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_HASH_COLS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_HASH_PARTITION_NUMS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_PRIMARY_KEY_COLS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_REPLICAS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_TABLE;
+import static org.apache.flink.connector.kudu.table.KuduCommonOptions.MASTERS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH_COLS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH_PARTITION_NUMS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.PRIMARY_KEY_COLS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.REPLICAS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.TABLE_NAME;
 import static org.apache.flink.util.Preconditions.checkArgument;
 import static org.apache.flink.util.Preconditions.checkNotNull;
 
@@ -186,13 +186,13 @@ public class KuduCatalog extends AbstractReadOnlyCatalog {
     protected Map<String, String> createTableProperties(
             String tableName, List<ColumnSchema> primaryKeyColumns) {
         Map<String, String> props = new HashMap<>();
-        props.put(KUDU_MASTERS.key(), kuduMasters);
-        props.put(KUDU_TABLE.key(), tableName);
+        props.put(MASTERS.key(), kuduMasters);
+        props.put(TABLE_NAME.key(), tableName);
         String primaryKeyNames =
                 primaryKeyColumns.stream()
                         .map(ColumnSchema::getName)
                         .collect(Collectors.joining(","));
-        props.put(KUDU_PRIMARY_KEY_COLS.key(), primaryKeyNames);
+        props.put(PRIMARY_KEY_COLS.key(), primaryKeyNames);
         return props;
     }
 
@@ -258,12 +258,11 @@ public class KuduCatalog extends AbstractReadOnlyCatalog {
         ResolvedSchema schema = ((ResolvedCatalogBaseTable<?>) table).getResolvedSchema();
 
         Set<String> optionalProperties =
-                ImmutableSet.of(
-                        KUDU_REPLICAS.key(), KUDU_HASH_PARTITION_NUMS.key(), KUDU_HASH_COLS.key());
+                ImmutableSet.of(REPLICAS.key(), HASH_PARTITION_NUMS.key(), HASH_COLS.key());
 
         Set<String> requiredProperties = new HashSet<>();
         if (!schema.getPrimaryKey().isPresent()) {
-            requiredProperties.add(KUDU_PRIMARY_KEY_COLS.key());
+            requiredProperties.add(PRIMARY_KEY_COLS.key());
         }
 
         if (!tableProperties.keySet().containsAll(requiredProperties)) {

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/catalog/KuduCatalogFactory.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/catalog/KuduCatalogFactory.java
@@ -28,7 +28,7 @@ import org.apache.kudu.shaded.com.google.common.collect.Sets;
 
 import java.util.Set;
 
-import static org.apache.flink.connector.kudu.table.KuduCommonOptions.KUDU_MASTERS;
+import static org.apache.flink.connector.kudu.table.KuduCommonOptions.MASTERS;
 import static org.apache.flink.connector.kudu.table.catalog.KuduCatalogOptions.DEFAULT_DATABASE;
 import static org.apache.flink.connector.kudu.table.catalog.KuduCatalogOptions.IDENTIFIER;
 import static org.apache.flink.table.factories.FactoryUtil.PROPERTY_VERSION;
@@ -44,7 +44,7 @@ public class KuduCatalogFactory implements CatalogFactory {
 
     @Override
     public Set<ConfigOption<?>> requiredOptions() {
-        return Sets.newHashSet(KUDU_MASTERS);
+        return Sets.newHashSet(MASTERS);
     }
 
     @Override
@@ -61,6 +61,6 @@ public class KuduCatalogFactory implements CatalogFactory {
         return new KuduCatalog(
                 context.getName(),
                 helper.getOptions().get(DEFAULT_DATABASE),
-                helper.getOptions().get(KUDU_MASTERS));
+                helper.getOptions().get(MASTERS));
     }
 }

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/utils/KuduTableUtils.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/utils/KuduTableUtils.java
@@ -49,10 +49,10 @@ import java.util.Map;
 import java.util.Optional;
 import java.util.stream.Collectors;
 
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_HASH_COLS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_HASH_PARTITION_NUMS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_PRIMARY_KEY_COLS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.KUDU_REPLICAS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH_COLS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH_PARTITION_NUMS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.PRIMARY_KEY_COLS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.REPLICAS;
 
 /** Kudu table utilities. */
 public class KuduTableUtils {
@@ -64,8 +64,7 @@ public class KuduTableUtils {
         // Since KUDU_HASH_COLS is a required property for table creation, we use it to infer
         // whether to create table
         boolean createIfMissing =
-                props.containsKey(KUDU_PRIMARY_KEY_COLS.key())
-                        || schema.getPrimaryKey().isPresent();
+                props.containsKey(PRIMARY_KEY_COLS.key()) || schema.getPrimaryKey().isPresent();
         KuduTableInfo tableInfo = KuduTableInfo.forTable(tableName);
 
         if (createIfMissing) {
@@ -77,12 +76,10 @@ public class KuduTableUtils {
 
             ColumnSchemasFactory schemasFactory = () -> toKuduConnectorColumns(columns, keyColumns);
             int replicas =
-                    Optional.ofNullable(props.get(KUDU_REPLICAS.key()))
-                            .map(Integer::parseInt)
-                            .orElse(1);
+                    Optional.ofNullable(props.get(REPLICAS.key())).map(Integer::parseInt).orElse(1);
             // if hash partitions nums not exists,default 3;
             int hashPartitionNums =
-                    Optional.ofNullable(props.get(KUDU_HASH_PARTITION_NUMS.key()))
+                    Optional.ofNullable(props.get(HASH_PARTITION_NUMS.key()))
                             .map(Integer::parseInt)
                             .orElse(3);
             CreateTableOptionsFactory optionsFactory =
@@ -94,7 +91,7 @@ public class KuduTableUtils {
         } else {
             LOG.debug(
                     "Property {} is missing, assuming the table is already created.",
-                    KUDU_HASH_COLS.key());
+                    HASH_COLS.key());
         }
 
         return tableInfo;
@@ -141,13 +138,13 @@ public class KuduTableUtils {
 
     public static List<String> getPrimaryKeyColumns(
             Map<String, String> tableProperties, ResolvedSchema schema) {
-        return tableProperties.containsKey(KUDU_PRIMARY_KEY_COLS.key())
-                ? Arrays.asList(tableProperties.get(KUDU_PRIMARY_KEY_COLS.key()).split(","))
+        return tableProperties.containsKey(PRIMARY_KEY_COLS.key())
+                ? Arrays.asList(tableProperties.get(PRIMARY_KEY_COLS.key()).split(","))
                 : schema.getPrimaryKey().get().getColumns();
     }
 
     public static List<String> getHashColumns(Map<String, String> tableProperties) {
-        return Arrays.asList(tableProperties.get(KUDU_HASH_COLS.key()).split(","));
+        return Arrays.asList(tableProperties.get(HASH_COLS.key()).split(","));
     }
 
     /** Converts Flink Expression to KuduFilterInfo. */

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSinkTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSinkTest.java
@@ -64,17 +64,17 @@ public class KuduDynamicSinkTest extends KuduTestBase {
                         + "quantity int"
                         + ") WITH ("
                         + "  'connector'='kudu',"
-                        + "  'kudu.masters'='"
+                        + "  'masters'='"
                         + 123245
                         + "',"
-                        + "  'kudu.table'='"
+                        + "  'table-name'='"
                         + INPUT_TABLE
-                        + "','kudu.primary-key-columns'='id"
-                        + "','kudu.max-buffer-size'='1024"
-                        + "','kudu.flush-interval'='1000"
-                        + "','kudu.operation-timeout'='500"
-                        + "','kudu.ignore-not-found'='true"
-                        + "','kudu.ignore-duplicate'='true'"
+                        + "','primary-key-columns'='id"
+                        + "','sink.max-buffer-size'='1024"
+                        + "','sink.flush-interval'='1000ms"
+                        + "','sink.operation-timeout'='500ms"
+                        + "','sink.ignore-not-found'='true"
+                        + "','sink.ignore-duplicate'='true'"
                         + ")";
         tEnv.executeSql(createSql);
         tEnv.executeSql(

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSourceTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSourceTest.java
@@ -71,14 +71,14 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                         + "quantity int"
                         + ") WITH ("
                         + "  'connector'='kudu',"
-                        + "  'kudu.masters'='"
+                        + "  'masters'='"
                         + getMasterAddress()
                         + "',"
-                        + "  'kudu.table'='"
+                        + "  'table-name'='"
                         + INPUT_TABLE
                         + "',"
-                        + "'kudu.scan.row-size'='10',"
-                        + "'kudu.primary-key-columns'='id'"
+                        + "'scan.row-size'='10',"
+                        + "'primary-key-columns'='id'"
                         + ")");
 
         Iterator<Row> collected = tEnv.executeSql("SELECT * FROM " + INPUT_TABLE).collect();
@@ -98,14 +98,14 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                         + "quantity int"
                         + ") WITH ("
                         + "  'connector'='kudu',"
-                        + "  'kudu.masters'='"
+                        + "  'masters'='"
                         + getMasterAddress()
                         + "',"
-                        + "  'kudu.table'='"
+                        + "  'table-name'='"
                         + INPUT_TABLE
                         + "',"
-                        + "'kudu.scan.row-size'='10',"
-                        + "'kudu.primary-key-columns'='id'"
+                        + "'scan.row-size'='10',"
+                        + "'primary-key-columns'='id'"
                         + ")");
 
         Iterator<Row> collected =
@@ -141,14 +141,14 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                         + "quantity int"
                         + ") WITH ("
                         + "  'connector'='kudu',"
-                        + "  'kudu.masters'='"
+                        + "  'masters'='"
                         + getMasterAddress()
                         + "',"
-                        + "  'kudu.table'='"
+                        + "  'table-name'='"
                         + INPUT_TABLE
                         + "',"
-                        + "'kudu.scan.row-size'='10',"
-                        + "'kudu.primary-key-columns'='id'"
+                        + "'scan.row-size'='10',"
+                        + "'primary-key-columns'='id'"
                         + ")");
 
         Iterator<Row> collected =
@@ -174,14 +174,14 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                         + "quantity int"
                         + ") WITH ("
                         + "  'connector'='kudu',"
-                        + "  'kudu.masters'='"
+                        + "  'masters'='"
                         + getMasterAddress()
                         + "',"
-                        + "  'kudu.table'='"
+                        + "  'table-name'='"
                         + INPUT_TABLE
                         + "',"
-                        + "'kudu.scan.row-size'='10',"
-                        + "'kudu.primary-key-columns'='id'"
+                        + "'scan.row-size'='10',"
+                        + "'primary-key-columns'='id'"
                         + ")");
 
         tEnv.executeSql(

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactoryTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactoryTest.java
@@ -76,7 +76,7 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
     public void testMissingMasters() throws Exception {
         tableEnv.executeSql(
                 "CREATE TABLE TestTable11 (`first` STRING, `second` INT) "
-                        + "WITH ('connector'='kudu', 'kudu.table'='TestTable11')");
+                        + "WITH ('connector'='kudu', 'table-name'='TestTable11')");
         assertThrows(
                 ValidationException.class,
                 () -> tableEnv.executeSql("INSERT INTO TestTable11 values ('f', 1)"));
@@ -86,7 +86,7 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
     public void testNonExistingTable() throws Exception {
         tableEnv.executeSql(
                 "CREATE TABLE TestTable11 (`first` STRING, `second` INT) "
-                        + "WITH ('connector'='kudu', 'kudu.table'='TestTable11', 'kudu.masters'='"
+                        + "WITH ('connector'='kudu', 'table-name'='TestTable11', 'masters'='"
                         + kuduMasters
                         + "')");
         JobClient jobClient =
@@ -103,10 +103,10 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
     public void testCreateTable() throws Exception {
         tableEnv.executeSql(
                 "CREATE TABLE TestTable11 (`first` STRING, `second` STRING) "
-                        + "WITH ('connector'='kudu', 'kudu.table'='TestTable11', 'kudu.masters'='"
+                        + "WITH ('connector'='kudu', 'table-name'='TestTable11', 'masters'='"
                         + kuduMasters
                         + "', "
-                        + "'kudu.hash-columns'='first', 'kudu.primary-key-columns'='first')");
+                        + "'hash-columns'='first', 'primary-key-columns'='first')");
 
         tableEnv.executeSql("INSERT INTO TestTable11 values ('f', 's')")
                 .getJobClient()
@@ -123,10 +123,10 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
         // Test it when creating the table...
         tableEnv.executeSql(
                 "CREATE TABLE TestTableTs (`first` STRING, `second` TIMESTAMP(3)) "
-                        + "WITH ('connector'='kudu', 'kudu.masters'='"
+                        + "WITH ('connector'='kudu', 'masters'='"
                         + kuduMasters
                         + "', "
-                        + "'kudu.hash-columns'='first', 'kudu.primary-key-columns'='first')");
+                        + "'hash-columns'='first', 'primary-key-columns'='first')");
         tableEnv.executeSql(
                         "INSERT INTO TestTableTs values ('f', TIMESTAMP '2020-01-01 12:12:12.123456')")
                 .getJobClient()
@@ -160,10 +160,10 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
         // Creating a table
         tableEnv.executeSql(
                 "CREATE TABLE TestTable12 (`first` STRING, `second` STRING) "
-                        + "WITH ('connector'='kudu', 'kudu.table'='TestTable12', 'kudu.masters'='"
+                        + "WITH ('connector'='kudu', 'table-name'='TestTable12', 'masters'='"
                         + kuduMasters
                         + "', "
-                        + "'kudu.hash-columns'='first', 'kudu.primary-key-columns'='first')");
+                        + "'hash-columns'='first', 'primary-key-columns'='first')");
 
         tableEnv.executeSql("INSERT INTO TestTable12 values ('f', 's')")
                 .getJobClient()
@@ -174,7 +174,7 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
         // Then another one in SQL that refers to the previously created one
         tableEnv.executeSql(
                 "CREATE TABLE TestTable12b (`first` STRING, `second` STRING) "
-                        + "WITH ('connector'='kudu', 'kudu.table'='TestTable12', 'kudu.masters'='"
+                        + "WITH ('connector'='kudu', 'table-name'='TestTable12', 'masters'='"
                         + kuduMasters
                         + "')");
         tableEnv.executeSql("INSERT INTO TestTable12b values ('f2','s2')")
@@ -204,13 +204,13 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
                         Column.physical("second", DataTypes.STRING()));
         final Map<String, String> properties = new HashMap<>();
         properties.put("connector", "kudu");
-        properties.put("kudu.masters", kuduMasters);
-        properties.put("kudu.table", "TestTable12");
-        properties.put("kudu.ignore-not-found", "true");
-        properties.put("kudu.ignore-duplicate", "true");
-        properties.put("kudu.flush-mode", "auto_flush_sync");
-        properties.put("kudu.flush-interval", "10000");
-        properties.put("kudu.max-buffer-size", "10000");
+        properties.put("masters", kuduMasters);
+        properties.put("table-name", "TestTable12");
+        properties.put("sink.ignore-not-found", "true");
+        properties.put("sink.ignore-duplicate", "true");
+        properties.put("sink.flush-mode", "auto_flush_sync");
+        properties.put("sink.flush-interval", "10000");
+        properties.put("sink.max-buffer-size", "10000");
 
         KuduWriterConfig.Builder builder =
                 KuduWriterConfig.Builder.setMasters(kuduMasters)

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/catalog/KuduCatalogTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/catalog/KuduCatalogTest.java
@@ -69,7 +69,7 @@ public class KuduCatalogTest extends KuduTestBase {
     @Test
     public void testCreateAlterDrop() throws Exception {
         tableEnv.executeSql(
-                "CREATE TABLE TestTable1 (`first` STRING, `second` String) WITH ('kudu.hash-columns' = 'first', 'kudu.primary-key-columns' = 'first')");
+                "CREATE TABLE TestTable1 (`first` STRING, `second` String) WITH ('hash-columns' = 'first', 'primary-key-columns' = 'first')");
         tableEnv.executeSql("INSERT INTO TestTable1 VALUES ('f', 's')")
                 .getJobClient()
                 .get()
@@ -78,7 +78,7 @@ public class KuduCatalogTest extends KuduTestBase {
 
         // Add this once Primary key support has been enabled
         // tableEnv.sqlUpdate("CREATE TABLE TestTable2 (`first` STRING, `second` String, PRIMARY
-        // KEY(`first`)) WITH ('kudu.hash-columns' = 'first')");
+        // KEY(`first`)) WITH ('hash-columns' = 'first')");
         // tableEnv.sqlUpdate("INSERT INTO TestTable2 VALUES ('f', 's')");
 
         validateSingleKey("TestTable1");
@@ -94,7 +94,7 @@ public class KuduCatalogTest extends KuduTestBase {
     @Test
     public void testCreateAndInsertMultiKey() throws Exception {
         tableEnv.executeSql(
-                "CREATE TABLE TestTable3 (`first` STRING, `second` INT, third STRING) WITH ('kudu.hash-columns' = 'first,second', 'kudu.primary-key-columns' = 'first,second')");
+                "CREATE TABLE TestTable3 (`first` STRING, `second` INT, third STRING) WITH ('hash-columns' = 'first,second', 'primary-key-columns' = 'first,second')");
         tableEnv.executeSql("INSERT INTO TestTable3 VALUES ('f', 2, 't')")
                 .getJobClient()
                 .get()
@@ -107,7 +107,7 @@ public class KuduCatalogTest extends KuduTestBase {
     @Test
     public void testSourceProjection() throws Exception {
         tableEnv.executeSql(
-                "CREATE TABLE TestTable5 (`second` String, `first` STRING, `third` String) WITH ('kudu.hash-columns' = 'second', 'kudu.primary-key-columns' = 'second')");
+                "CREATE TABLE TestTable5 (`second` String, `first` STRING, `third` String) WITH ('hash-columns' = 'second', 'primary-key-columns' = 'second')");
         tableEnv.executeSql("INSERT INTO TestTable5 VALUES ('s', 'f', 't')")
                 .getJobClient()
                 .get()
@@ -115,7 +115,7 @@ public class KuduCatalogTest extends KuduTestBase {
                 .get(1, TimeUnit.MINUTES);
 
         tableEnv.executeSql(
-                "CREATE TABLE TestTable6 (`first` STRING, `second` String) WITH ('kudu.hash-columns' = 'first', 'kudu.primary-key-columns' = 'first')");
+                "CREATE TABLE TestTable6 (`first` STRING, `second` String) WITH ('hash-columns' = 'first', 'primary-key-columns' = 'first')");
         tableEnv.executeSql("INSERT INTO TestTable6 (SELECT `first`, `second` FROM  TestTable5)")
                 .getJobClient()
                 .get()
@@ -129,7 +129,7 @@ public class KuduCatalogTest extends KuduTestBase {
     public void testEmptyProjection() throws Exception {
         CollectionSink.output.clear();
         tableEnv.executeSql(
-                "CREATE TABLE TestTableEP (`first` STRING, `second` STRING) WITH ('kudu.hash-columns' = 'first', 'kudu.primary-key-columns' = 'first')");
+                "CREATE TABLE TestTableEP (`first` STRING, `second` STRING) WITH ('hash-columns' = 'first', 'primary-key-columns' = 'first')");
         tableEnv.executeSql("INSERT INTO TestTableEP VALUES ('f','s')")
                 .getJobClient()
                 .get()
@@ -165,7 +165,7 @@ public class KuduCatalogTest extends KuduTestBase {
     public void testTimestamp() throws Exception {
         tableEnv.executeSql(
                 "CREATE TABLE TestTableTsC (`first` STRING, `second` TIMESTAMP(3)) "
-                        + "WITH ('kudu.hash-columns'='first', 'kudu.primary-key-columns'='first')");
+                        + "WITH ('hash-columns'='first', 'primary-key-columns'='first')");
         tableEnv.executeSql(
                         "INSERT INTO TestTableTsC values ('f', TIMESTAMP '2020-01-01 12:12:12.123456')")
                 .getJobClient()
@@ -191,7 +191,7 @@ public class KuduCatalogTest extends KuduTestBase {
                 "CREATE TABLE TestTable8 (`first` STRING, `second` BOOLEAN, `third` BYTES,"
                         + "`fourth` TINYINT, `fifth` SMALLINT, `sixth` INT, `seventh` BIGINT, `eighth` FLOAT, `ninth` DOUBLE, "
                         + "`tenth` TIMESTAMP)"
-                        + "WITH ('kudu.hash-columns' = 'first', 'kudu.primary-key-columns' = 'first')");
+                        + "WITH ('hash-columns' = 'first', 'primary-key-columns' = 'first')");
 
         tableEnv.executeSql(
                         "INSERT INTO TestTable8 values ('f', false, cast('bbbb' as BYTES), cast(12 as TINYINT),"
@@ -212,19 +212,19 @@ public class KuduCatalogTest extends KuduTestBase {
                 () ->
                         tableEnv.executeSql(
                                 "CREATE TABLE TestTable9a (`first` STRING, `second` String) "
-                                        + "WITH ('kudu.primary-key-columns' = 'second')"));
+                                        + "WITH ('primary-key-columns' = 'second')"));
         assertThrows(
                 TableException.class,
                 () ->
                         tableEnv.executeSql(
                                 "CREATE TABLE TestTable9b (`first` STRING, `second` String) "
-                                        + "WITH ('kudu.hash-columns' = 'first')"));
+                                        + "WITH ('hash-columns' = 'first')"));
         assertThrows(
                 TableException.class,
                 () ->
                         tableEnv.executeSql(
                                 "CREATE TABLE TestTable9b (`first` STRING, `second` String) "
-                                        + "WITH ('kudu.primary-key-columns' = 'second', 'kudu.hash-columns' = 'first')"));
+                                        + "WITH ('primary-key-columns' = 'second', 'hash-columns' = 'first')"));
     }
 
     private void validateManyTypes(String tableName) throws Exception {


### PR DESCRIPTION
Relevant changes:
- removed `kudu` prefix from table option keys
- added `sink` prefix for relevant table options
- adapted tests

I will handle the documentation in a different ticket. I plan to write more meaningful descriptions.