### PR TITLE
[FLINK-37237] Improve Kudu table creation based on Flink SQL `CREATE TABLE`

### DIFF
--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactory.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactory.java
@@ -43,13 +43,12 @@ import static org.apache.flink.connector.kudu.table.KuduCommonOptions.MASTERS;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.FLUSH_INTERVAL;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.FLUSH_MODE;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH_COLS;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH_PARTITION_NUMS;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH_PARTITIONS;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.IDENTIFIER;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.IGNORE_DUPLICATE;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.IGNORE_NOT_FOUND;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.MAX_BUFFER_SIZE;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.OPERATION_TIMEOUT;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.PRIMARY_KEY_COLS;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.REPLICAS;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.SCAN_ROW_SIZE;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.TABLE_NAME;
@@ -75,8 +74,7 @@ public class KuduDynamicTableFactory implements DynamicTableSourceFactory, Dynam
         return Sets.newHashSet(
                 TABLE_NAME,
                 HASH_COLS,
-                HASH_PARTITION_NUMS,
-                PRIMARY_KEY_COLS,
+                HASH_PARTITIONS,
                 SCAN_ROW_SIZE,
                 REPLICAS,
                 MAX_BUFFER_SIZE,

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableOptions.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableOptions.java
@@ -43,24 +43,17 @@ public class KuduDynamicTableOptions {
                     .noDefaultValue()
                     .withDescription("kudu's hash columns");
 
-    public static final ConfigOption<String> PRIMARY_KEY_COLS =
-            ConfigOptions.key("primary-key-columns")
-                    .stringType()
-                    .noDefaultValue()
-                    .withDescription("kudu's primary key, primary key must be ordered");
-
     public static final ConfigOption<Integer> REPLICAS =
             ConfigOptions.key("replicas")
                     .intType()
                     .defaultValue(3)
                     .withDescription("kudu's replica nums");
 
-    public static final ConfigOption<Integer> HASH_PARTITION_NUMS =
-            ConfigOptions.key("hash-partition-nums")
+    public static final ConfigOption<Integer> HASH_PARTITIONS =
+            ConfigOptions.key("hash-partitions")
                     .intType()
-                    .defaultValue(REPLICAS.defaultValue() * 2)
-                    .withDescription(
-                            "kudu's hash partition bucket nums, defaultValue is 2 * replicas");
+                    .defaultValue(3)
+                    .withDescription("kudu's hash partition bucket number, default value is 3");
 
     // -----------------------------------------------------------------------------------------
     // Sink options

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSinkTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSinkTest.java
@@ -57,7 +57,7 @@ public class KuduDynamicSinkTest extends KuduTestBase {
                 "CREATE TABLE "
                         + INPUT_TABLE
                         + "("
-                        + "id int,"
+                        + "id int PRIMARY KEY NOT ENFORCED,"
                         + "title string,"
                         + "author string,"
                         + "price double,"
@@ -69,7 +69,6 @@ public class KuduDynamicSinkTest extends KuduTestBase {
                         + "',"
                         + "  'table-name'='"
                         + INPUT_TABLE
-                        + "','primary-key-columns'='id"
                         + "','sink.max-buffer-size'='1024"
                         + "','sink.flush-interval'='1000ms"
                         + "','sink.operation-timeout'='500ms"

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSourceTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSourceTest.java
@@ -64,7 +64,7 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                 "CREATE TABLE "
                         + INPUT_TABLE
                         + "("
-                        + "id int,"
+                        + "id int PRIMARY KEY NOT ENFORCED,"
                         + "title string,"
                         + "author string,"
                         + "price double,"
@@ -77,8 +77,7 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                         + "  'table-name'='"
                         + INPUT_TABLE
                         + "',"
-                        + "'scan.row-size'='10',"
-                        + "'primary-key-columns'='id'"
+                        + "'scan.row-size'='10'"
                         + ")");
 
         Iterator<Row> collected = tEnv.executeSql("SELECT * FROM " + INPUT_TABLE).collect();
@@ -91,7 +90,7 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                 "CREATE TABLE "
                         + INPUT_TABLE
                         + "("
-                        + "id int,"
+                        + "id int PRIMARY KEY NOT ENFORCED,"
                         + "title string,"
                         + "author string,"
                         + "price double,"
@@ -104,8 +103,7 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                         + "  'table-name'='"
                         + INPUT_TABLE
                         + "',"
-                        + "'scan.row-size'='10',"
-                        + "'primary-key-columns'='id'"
+                        + "'scan.row-size'='10'"
                         + ")");
 
         Iterator<Row> collected =
@@ -134,7 +132,7 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                 "CREATE TABLE "
                         + INPUT_TABLE
                         + "("
-                        + "id int,"
+                        + "id int PRIMARY KEY NOT ENFORCED,"
                         + "title string,"
                         + "author string,"
                         + "price double,"
@@ -147,8 +145,7 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                         + "  'table-name'='"
                         + INPUT_TABLE
                         + "',"
-                        + "'scan.row-size'='10',"
-                        + "'primary-key-columns'='id'"
+                        + "'scan.row-size'='10'"
                         + ")");
 
         Iterator<Row> collected =
@@ -167,7 +164,7 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                 "CREATE TABLE "
                         + INPUT_TABLE
                         + "("
-                        + "id int,"
+                        + "id int PRIMARY KEY NOT ENFORCED,"
                         + "title string,"
                         + "author string,"
                         + "price double,"
@@ -180,8 +177,7 @@ public class KuduDynamicSourceTest extends KuduTestBase {
                         + "  'table-name'='"
                         + INPUT_TABLE
                         + "',"
-                        + "'scan.row-size'='10',"
-                        + "'primary-key-columns'='id'"
+                        + "'scan.row-size'='10'"
                         + ")");
 
         tEnv.executeSql(

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactoryTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactoryTest.java
@@ -102,11 +102,28 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
     @Test
     public void testCreateTable() throws Exception {
         tableEnv.executeSql(
-                "CREATE TABLE TestTable11 (`first` STRING, `second` STRING) "
+                "CREATE TABLE TestTable11 (`first` STRING PRIMARY KEY NOT ENFORCED, `second` STRING) "
+                        + "WITH ('connector'='kudu', 'table-name'='TestTable11', 'masters'='"
+                        + kuduMasters
+                        + "')");
+
+        tableEnv.executeSql("INSERT INTO TestTable11 values ('f', 's')")
+                .getJobClient()
+                .get()
+                .getJobExecutionResult()
+                .get(1, TimeUnit.MINUTES);
+
+        validateSingleKey("TestTable11");
+    }
+
+    @Test
+    public void testCreateTableWithDifferentHashCols() throws Exception {
+        tableEnv.executeSql(
+                "CREATE TABLE TestTable11 (`first` STRING PRIMARY KEY NOT ENFORCED, `second` STRING) "
                         + "WITH ('connector'='kudu', 'table-name'='TestTable11', 'masters'='"
                         + kuduMasters
                         + "', "
-                        + "'hash-columns'='first', 'primary-key-columns'='first')");
+                        + "'hash-columns'='first,second')");
 
         tableEnv.executeSql("INSERT INTO TestTable11 values ('f', 's')")
                 .getJobClient()
@@ -122,11 +139,10 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
         // Timestamp should be bridged to sql.Timestamp
         // Test it when creating the table...
         tableEnv.executeSql(
-                "CREATE TABLE TestTableTs (`first` STRING, `second` TIMESTAMP(3)) "
+                "CREATE TABLE TestTableTs (`first` STRING PRIMARY KEY NOT ENFORCED, `second` TIMESTAMP(3)) "
                         + "WITH ('connector'='kudu', 'masters'='"
                         + kuduMasters
-                        + "', "
-                        + "'hash-columns'='first', 'primary-key-columns'='first')");
+                        + "')");
         tableEnv.executeSql(
                         "INSERT INTO TestTableTs values ('f', TIMESTAMP '2020-01-01 12:12:12.123456')")
                 .getJobClient()
@@ -159,11 +175,10 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
     public void testExistingTable() throws Exception {
         // Creating a table
         tableEnv.executeSql(
-                "CREATE TABLE TestTable12 (`first` STRING, `second` STRING) "
+                "CREATE TABLE TestTable12 (`first` STRING PRIMARY KEY NOT ENFORCED, `second` STRING) "
                         + "WITH ('connector'='kudu', 'table-name'='TestTable12', 'masters'='"
                         + kuduMasters
-                        + "', "
-                        + "'hash-columns'='first', 'primary-key-columns'='first')");
+                        + "')");
 
         tableEnv.executeSql("INSERT INTO TestTable12 values ('f', 's')")
                 .getJobClient()

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/catalog/KuduCatalogTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/catalog/KuduCatalogTest.java
@@ -69,7 +69,7 @@ public class KuduCatalogTest extends KuduTestBase {
     @Test
     public void testCreateAlterDrop() throws Exception {
         tableEnv.executeSql(
-                "CREATE TABLE TestTable1 (`first` STRING, `second` String) WITH ('hash-columns' = 'first', 'primary-key-columns' = 'first')");
+                "CREATE TABLE TestTable1 (`first` STRING PRIMARY KEY NOT ENFORCED, `second` String)");
         tableEnv.executeSql("INSERT INTO TestTable1 VALUES ('f', 's')")
                 .getJobClient()
                 .get()
@@ -94,7 +94,7 @@ public class KuduCatalogTest extends KuduTestBase {
     @Test
     public void testCreateAndInsertMultiKey() throws Exception {
         tableEnv.executeSql(
-                "CREATE TABLE TestTable3 (`first` STRING, `second` INT, third STRING) WITH ('hash-columns' = 'first,second', 'primary-key-columns' = 'first,second')");
+                "CREATE TABLE TestTable3 (`first` STRING, `second` INT, third STRING, PRIMARY KEY (`first`, `second`) NOT ENFORCED)");
         tableEnv.executeSql("INSERT INTO TestTable3 VALUES ('f', 2, 't')")
                 .getJobClient()
                 .get()
@@ -107,7 +107,7 @@ public class KuduCatalogTest extends KuduTestBase {
     @Test
     public void testSourceProjection() throws Exception {
         tableEnv.executeSql(
-                "CREATE TABLE TestTable5 (`second` String, `first` STRING, `third` String) WITH ('hash-columns' = 'second', 'primary-key-columns' = 'second')");
+                "CREATE TABLE TestTable5 (`second` String PRIMARY KEY NOT ENFORCED, `first` STRING, `third` String)");
         tableEnv.executeSql("INSERT INTO TestTable5 VALUES ('s', 'f', 't')")
                 .getJobClient()
                 .get()
@@ -115,7 +115,7 @@ public class KuduCatalogTest extends KuduTestBase {
                 .get(1, TimeUnit.MINUTES);
 
         tableEnv.executeSql(
-                "CREATE TABLE TestTable6 (`first` STRING, `second` String) WITH ('hash-columns' = 'first', 'primary-key-columns' = 'first')");
+                "CREATE TABLE TestTable6 (`first` STRING PRIMARY KEY NOT ENFORCED, `second` String)");
         tableEnv.executeSql("INSERT INTO TestTable6 (SELECT `first`, `second` FROM  TestTable5)")
                 .getJobClient()
                 .get()
@@ -129,7 +129,7 @@ public class KuduCatalogTest extends KuduTestBase {
     public void testEmptyProjection() throws Exception {
         CollectionSink.output.clear();
         tableEnv.executeSql(
-                "CREATE TABLE TestTableEP (`first` STRING, `second` STRING) WITH ('hash-columns' = 'first', 'primary-key-columns' = 'first')");
+                "CREATE TABLE TestTableEP (`first` STRING PRIMARY KEY NOT ENFORCED, `second` STRING)");
         tableEnv.executeSql("INSERT INTO TestTableEP VALUES ('f','s')")
                 .getJobClient()
                 .get()
@@ -164,8 +164,7 @@ public class KuduCatalogTest extends KuduTestBase {
     @Test
     public void testTimestamp() throws Exception {
         tableEnv.executeSql(
-                "CREATE TABLE TestTableTsC (`first` STRING, `second` TIMESTAMP(3)) "
-                        + "WITH ('hash-columns'='first', 'primary-key-columns'='first')");
+                "CREATE TABLE TestTableTsC (`first` STRING PRIMARY KEY NOT ENFORCED, `second` TIMESTAMP(3))");
         tableEnv.executeSql(
                         "INSERT INTO TestTableTsC values ('f', TIMESTAMP '2020-01-01 12:12:12.123456')")
                 .getJobClient()
@@ -188,10 +187,9 @@ public class KuduCatalogTest extends KuduTestBase {
     @Test
     public void testDatatypes() throws Exception {
         tableEnv.executeSql(
-                "CREATE TABLE TestTable8 (`first` STRING, `second` BOOLEAN, `third` BYTES,"
+                "CREATE TABLE TestTable8 (`first` STRING PRIMARY KEY NOT ENFORCED, `second` BOOLEAN, `third` BYTES,"
                         + "`fourth` TINYINT, `fifth` SMALLINT, `sixth` INT, `seventh` BIGINT, `eighth` FLOAT, `ninth` DOUBLE, "
-                        + "`tenth` TIMESTAMP)"
-                        + "WITH ('hash-columns' = 'first', 'primary-key-columns' = 'first')");
+                        + "`tenth` TIMESTAMP)");
 
         tableEnv.executeSql(
                         "INSERT INTO TestTable8 values ('f', false, cast('bbbb' as BYTES), cast(12 as TINYINT),"


### PR DESCRIPTION
Relevant changes in case the Kudu table will be created based on the Flink SQL table:
- `PRIMARY KEY` is now only accepted as part of the `CREATE TABLE` statement schema.
- The `primary-keys` table config option is removed completely.
- If `hash-columns` are not given those will be the same as the primary key columns (most common use-case).
- The `hash-partition-nums` renamed to `hash-partitions`, and default value changed to `3`.