### PR TITLE
[FLINK-37389] Add `flink-sql-connector-kudu` module

### DIFF
--- a/flink-connector-kudu/pom.xml
+++ b/flink-connector-kudu/pom.xml
@@ -36,43 +36,38 @@ under the License.
 	<dependencies>
 		<dependency>
 			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-clients</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-base</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-streaming-java</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-api-java-bridge</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-common</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-planner-loader</artifactId>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-table-runtime</artifactId>
-		</dependency>
-
-		<dependency>
-			<groupId>org.apache.flink</groupId>
-			<artifactId>flink-test-utils</artifactId>
-			<scope>test</scope>
+			<scope>provided</scope>
 		</dependency>
 
 		<dependency>
@@ -83,6 +78,26 @@ under the License.
 		<dependency>
 			<groupId>org.apache.flink</groupId>
 			<artifactId>flink-connector-test-utils</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-test-utils-junit</artifactId>
+			<scope>test</scope>
+		</dependency>
+
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-runtime</artifactId>
+			<version>${flink.version}</version>
+			<type>test-jar</type>
 			<scope>test</scope>
 		</dependency>
 

--- a/flink-sql-connector-kudu/pom.xml
+++ b/flink-sql-connector-kudu/pom.xml
@@ -1,0 +1,93 @@
+<?xml version="1.0" encoding="UTF-8"?>
+<!--
+Licensed to the Apache Software Foundation (ASF) under one
+or more contributor license agreements.  See the NOTICE file
+distributed with this work for additional information
+regarding copyright ownership.  The ASF licenses this file
+to you under the Apache License, Version 2.0 (the
+"License"); you may not use this file except in compliance
+with the License.  You may obtain a copy of the License at
+
+  http://www.apache.org/licenses/LICENSE-2.0
+
+Unless required by applicable law or agreed to in writing,
+software distributed under the License is distributed on an
+"AS IS" BASIS, WITHOUT WARRANTIES OR CONDITIONS OF ANY
+KIND, either express or implied.  See the License for the
+specific language governing permissions and limitations
+under the License.
+-->
+<project xmlns="http://maven.apache.org/POM/4.0.0"
+		 xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance"
+		 xsi:schemaLocation="http://maven.apache.org/POM/4.0.0 http://maven.apache.org/xsd/maven-4.0.0.xsd">
+
+	<modelVersion>4.0.0</modelVersion>
+
+	<parent>
+		<groupId>org.apache.flink</groupId>
+		<artifactId>flink-connector-kudu-parent</artifactId>
+		<version>2.0-SNAPSHOT</version>
+	</parent>
+
+	<artifactId>flink-sql-connector-kudu</artifactId>
+	<name>Flink : Connectors : SQL : Kudu</name>
+	<packaging>jar</packaging>
+
+	<dependencies>
+		<dependency>
+			<groupId>org.apache.flink</groupId>
+			<artifactId>flink-connector-kudu</artifactId>
+			<version>${project.version}</version>
+		</dependency>
+	</dependencies>
+
+	<build>
+		<plugins>
+			<plugin>
+				<groupId>org.apache.maven.plugins</groupId>
+				<artifactId>maven-shade-plugin</artifactId>
+				<executions>
+					<execution>
+						<id>shade-flink</id>
+						<phase>package</phase>
+						<goals>
+							<goal>shade</goal>
+						</goals>
+						<configuration>
+							<artifactSet>
+								<includes>
+									<include>*:*</include>
+								</includes>
+								<excludes>
+									<exclude>com.google.code.findbugs:jsr305</exclude>
+									<exclude>org.apache.yetus:*</exclude>
+									<exclude>org.slf4j:*</exclude>
+								</excludes>
+							</artifactSet>
+							<filters>
+								<filter>
+									<artifact>*:*</artifact>
+									<excludes>
+										<exclude>META-INF/native/libnetty**</exclude>
+										<exclude>META-INF/native-image/**</exclude>
+										<exclude>META-INF/services/reactor.blockhound.integration.BlockHoundIntegration</exclude>
+										<exclude>META-INF/io.netty.versions.properties</exclude>
+										<exclude>META-INF/micrometer-core.properties</exclude>
+										<exclude>META-INF/LICENSE.txt</exclude>
+									</excludes>
+								</filter>
+							</filters>
+							<relocations>
+								<relocation>
+									<pattern>org.apache.kudu</pattern>
+									<shadedPattern>org.apache.flink.kudu.shaded.org.apache.kudu</shadedPattern>
+								</relocation>
+							</relocations>
+						</configuration>
+					</execution>
+				</executions>
+			</plugin>
+		</plugins>
+	</build>
+
+</project>

--- a/flink-sql-connector-kudu/src/main/resources/META-INF/NOTICE
+++ b/flink-sql-connector-kudu/src/main/resources/META-INF/NOTICE
@@ -1,0 +1,14 @@
+flink-sql-connector-kudu
+Copyright 2014-2025 The Apache Software Foundation
+
+This product includes software developed at
+The Apache Software Foundation (http://www.apache.org/).
+
+This project bundles the following dependencies under the Apache Software License 2.0. (http://www.apache.org/licenses/LICENSE-2.0.txt)
+
+ - org.apache.kudu:kudu-client:1.17.1
+ - commons-codec:commons-codec:1.17.1
+
+This project bundles the following dependencies under the BSD-3 license (https://opensource.org/license/BSD-3-Clause).
+
+- com.stumbleupon:async:1.4.1

--- a/pom.xml
+++ b/pom.xml
@@ -74,6 +74,7 @@ under the License.
 
 	<modules>
 		<module>flink-connector-kudu</module>
+		<module>flink-sql-connector-kudu</module>
 	</modules>
 
 	<dependencies>
@@ -124,19 +125,7 @@ under the License.
 		<dependencies>
 			<dependency>
 				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-clients</artifactId>
-				<version>${flink.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-connector-base</artifactId>
-				<version>${flink.version}</version>
-			</dependency>
-
-			<dependency>
-				<groupId>org.apache.flink</groupId>
-				<artifactId>flink-connector-test-utils</artifactId>
 				<version>${flink.version}</version>
 			</dependency>
 
@@ -172,22 +161,30 @@ under the License.
 
 			<dependency>
 				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-connector-test-utils</artifactId>
+				<version>${flink.version}</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.flink</groupId>
 				<artifactId>flink-test-utils</artifactId>
 				<version>${flink.version}</version>
 				<exclusions>
 					<exclusion>
-						<groupId>org.apache.commons</groupId>
-						<artifactId>commons-compress</artifactId>
+						<groupId>org.apache.yetus</groupId>
+						<artifactId>audience-annotations</artifactId>
 					</exclusion>
 					<exclusion>
 						<groupId>org.xerial.snappy</groupId>
 						<artifactId>snappy-java</artifactId>
 					</exclusion>
-					<exclusion>
-						<groupId>org.apache.yetus</groupId>
-						<artifactId>audience-annotations</artifactId>
-					</exclusion>
 				</exclusions>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.flink</groupId>
+				<artifactId>flink-test-utils-junit</artifactId>
+				<version>${flink.version}</version>
 			</dependency>
 
 			<!-- Flink ArchUnit -->
@@ -284,6 +281,12 @@ under the License.
 				<groupId>com.esotericsoftware.kryo</groupId>
 				<artifactId>kryo</artifactId>
 				<version>2.24.0</version>
+			</dependency>
+
+			<dependency>
+				<groupId>org.apache.commons</groupId>
+				<artifactId>commons-compress</artifactId>
+				<version>1.26.0</version>
 			</dependency>
 
 			<dependency>


### PR DESCRIPTION
The `bahir-flink` repo connectors only built 1 artifact that was a fat JAR, although this is not the standard for the externalized Flink connector packaging. When a connector has both DataStream API and Table API implementations, we release a general connector artifact for DS API, that does not shade any transitive dependency, cause the intention is that is will be used as a dependency of a user application project, which should produce a fat JAR. On the other hand, for Table API, we release an `sql` JAR as well, which is a fat JAR that contains all transitive dependencies for the connector to function, so only that JAR has to be added to the Flink classpath.

# TODO

- [x] Add `NOTICE` file to the new module.