### PR TITLE
[FLINK-39374][Kudu] Rename max buffer size config option

### DIFF
--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/connector/writer/KuduWriter.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/connector/writer/KuduWriter.java
@@ -130,7 +130,7 @@ public class KuduWriter<T> implements SinkWriter<T> {
         KuduSession session = client.newSession();
         session.setFlushMode(writerConfig.getFlushMode());
         session.setTimeoutMillis(writerConfig.getOperationTimeout());
-        session.setMutationBufferSpace(writerConfig.getMaxBufferSize());
+        session.setMutationBufferSpace(writerConfig.getMaxMutationBufferOps());
         session.setFlushInterval(writerConfig.getFlushInterval());
         session.setIgnoreAllDuplicateRows(writerConfig.isIgnoreDuplicate());
         session.setIgnoreAllNotFoundRows(writerConfig.isIgnoreNotFound());

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/connector/writer/KuduWriterConfig.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/connector/writer/KuduWriterConfig.java
@@ -40,7 +40,7 @@ public class KuduWriterConfig implements Serializable {
     private final String masters;
     private final FlushMode flushMode;
     private final long operationTimeout;
-    private final int maxBufferSize;
+    private final int maxMutationBufferOps;
     private final int flushInterval;
     private final boolean ignoreNotFound;
     private final boolean ignoreDuplicate;
@@ -49,7 +49,7 @@ public class KuduWriterConfig implements Serializable {
             String masters,
             FlushMode flushMode,
             long operationTimeout,
-            int maxBufferSize,
+            int maxMutationBufferOps,
             int flushInterval,
             boolean ignoreNotFound,
             boolean ignoreDuplicate) {
@@ -57,7 +57,7 @@ public class KuduWriterConfig implements Serializable {
         this.masters = checkNotNull(masters, "Kudu masters cannot be null");
         this.flushMode = checkNotNull(flushMode, "Kudu flush mode cannot be null");
         this.operationTimeout = operationTimeout;
-        this.maxBufferSize = maxBufferSize;
+        this.maxMutationBufferOps = maxMutationBufferOps;
         this.flushInterval = flushInterval;
         this.ignoreNotFound = ignoreNotFound;
         this.ignoreDuplicate = ignoreDuplicate;
@@ -75,8 +75,14 @@ public class KuduWriterConfig implements Serializable {
         return operationTimeout;
     }
 
+    public int getMaxMutationBufferOps() {
+        return maxMutationBufferOps;
+    }
+
+    /** @deprecated Use {@link #getMaxMutationBufferOps()} instead. */
+    @Deprecated
     public int getMaxBufferSize() {
-        return maxBufferSize;
+        return getMaxMutationBufferOps();
     }
 
     public int getFlushInterval() {
@@ -106,7 +112,7 @@ public class KuduWriterConfig implements Serializable {
         // Reference from AsyncKuduClientBuilder defaultOperationTimeoutMs.
         private long timeout = AsyncKuduClient.DEFAULT_OPERATION_TIMEOUT_MS;
         // Reference from AsyncKuduSession mutationBufferMaxOps 1000.
-        private int maxBufferSize = 1000;
+        private int maxMutationBufferOps = 1000;
         // Reference from AsyncKuduSession flushIntervalMillis 1000.
         private int flushInterval = 1000;
         // Reference from AsyncKuduSession ignoreAllNotFoundRows false.
@@ -135,9 +141,15 @@ public class KuduWriterConfig implements Serializable {
             return setConsistency(FlushMode.AUTO_FLUSH_SYNC);
         }
 
-        public Builder setMaxBufferSize(int maxBufferSize) {
-            this.maxBufferSize = maxBufferSize;
+        public Builder setMaxMutationBufferOps(int maxMutationBufferOps) {
+            this.maxMutationBufferOps = maxMutationBufferOps;
             return this;
+        }
+
+        /** @deprecated Use {@link #setMaxMutationBufferOps(int)} instead. */
+        @Deprecated
+        public Builder setMaxBufferSize(int maxBufferSize) {
+            return setMaxMutationBufferOps(maxBufferSize);
         }
 
         public Builder setFlushInterval(int flushInterval) {
@@ -165,7 +177,7 @@ public class KuduWriterConfig implements Serializable {
                     masters,
                     flushMode,
                     timeout,
-                    maxBufferSize,
+                    maxMutationBufferOps,
                     flushInterval,
                     ignoreNotFound,
                     ignoreDuplicate);
@@ -178,7 +190,7 @@ public class KuduWriterConfig implements Serializable {
                             masters,
                             flushMode,
                             timeout,
-                            maxBufferSize,
+                            maxMutationBufferOps,
                             flushInterval,
                             ignoreNotFound,
                             ignoreDuplicate);
@@ -197,7 +209,7 @@ public class KuduWriterConfig implements Serializable {
             return Objects.equals(masters, that.masters)
                     && Objects.equals(flushMode, that.flushMode)
                     && Objects.equals(timeout, that.timeout)
-                    && Objects.equals(maxBufferSize, that.maxBufferSize)
+                    && Objects.equals(maxMutationBufferOps, that.maxMutationBufferOps)
                     && Objects.equals(flushInterval, that.flushInterval)
                     && Objects.equals(ignoreNotFound, that.ignoreNotFound)
                     && Objects.equals(ignoreDuplicate, that.ignoreDuplicate);

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactory.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactory.java
@@ -47,7 +47,7 @@ import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.HASH
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.IDENTIFIER;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.IGNORE_DUPLICATE;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.IGNORE_NOT_FOUND;
-import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.MAX_BUFFER_SIZE;
+import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.MAX_MUTATION_BUFFER_OPS;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.OPERATION_TIMEOUT;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.REPLICAS;
 import static org.apache.flink.connector.kudu.table.KuduDynamicTableOptions.SCAN_ROW_SIZE;
@@ -77,7 +77,7 @@ public class KuduDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                 HASH_PARTITIONS,
                 SCAN_ROW_SIZE,
                 REPLICAS,
-                MAX_BUFFER_SIZE,
+                MAX_MUTATION_BUFFER_OPS,
                 OPERATION_TIMEOUT,
                 FLUSH_MODE,
                 FLUSH_INTERVAL,
@@ -108,7 +108,7 @@ public class KuduDynamicTableFactory implements DynamicTableSourceFactory, Dynam
                         .setOperationTimeout(config.get(OPERATION_TIMEOUT).toMillis())
                         .setConsistency(config.get(FLUSH_MODE))
                         .setFlushInterval((int) config.get(FLUSH_INTERVAL).toMillis())
-                        .setMaxBufferSize(config.get(MAX_BUFFER_SIZE))
+                        .setMaxMutationBufferOps(config.get(MAX_MUTATION_BUFFER_OPS))
                         .setIgnoreNotFound(config.get(IGNORE_NOT_FOUND))
                         .setIgnoreDuplicate(config.get(IGNORE_DUPLICATE));
 

--- a/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableOptions.java
+++ b/flink-connector-kudu/src/main/java/org/apache/flink/connector/kudu/table/KuduDynamicTableOptions.java
@@ -59,11 +59,23 @@ public class KuduDynamicTableOptions {
     // Sink options
     // -----------------------------------------------------------------------------------------
 
+    public static final ConfigOption<Integer> MAX_MUTATION_BUFFER_OPS =
+            ConfigOptions.key("sink.max-mutation-buffer-ops")
+                    .intType()
+                    .defaultValue(1000)
+                    .withDeprecatedKeys("sink.max-buffer-size")
+                    .withDescription("kudu's maximum number of buffered mutation operations");
+
+    /** @deprecated Use {@link #MAX_MUTATION_BUFFER_OPS} instead. */
+    @Deprecated
     public static final ConfigOption<Integer> MAX_BUFFER_SIZE =
             ConfigOptions.key("sink.max-buffer-size")
                     .intType()
                     .defaultValue(1000)
-                    .withDescription("kudu's max buffer size");
+                    .withDescription(
+                            "Deprecated. Use sink.max-mutation-buffer-ops instead."
+                                    + " This option configures kudu's maximum number of buffered"
+                                    + " mutation operations.");
 
     public static final ConfigOption<SessionConfiguration.FlushMode> FLUSH_MODE =
             ConfigOptions.key("sink.flush-mode")

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/connector/writer/KuduWriterConfigTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/connector/writer/KuduWriterConfigTest.java
@@ -1,0 +1,46 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kudu.connector.writer;
+
+import org.junit.jupiter.api.Test;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for {@link KuduWriterConfig}. */
+class KuduWriterConfigTest {
+
+    @Test
+    void testBuilderUsesMaxMutationBufferOps() {
+        KuduWriterConfig config =
+                KuduWriterConfig.Builder.setMasters("localhost")
+                        .setMaxMutationBufferOps(42)
+                        .build();
+
+        assertEquals(42, config.getMaxMutationBufferOps());
+        assertEquals(42, config.getMaxBufferSize());
+    }
+
+    @Test
+    void testDeprecatedMaxBufferSizeSetterStillConfiguresMutationBufferOps() {
+        KuduWriterConfig config =
+                KuduWriterConfig.Builder.setMasters("localhost").setMaxBufferSize(24).build();
+
+        assertEquals(24, config.getMaxMutationBufferOps());
+        assertEquals(24, config.getMaxBufferSize());
+    }
+}

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSinkTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicSinkTest.java
@@ -69,7 +69,7 @@ public class KuduDynamicSinkTest extends KuduTestBase {
                         + "',"
                         + "  'table-name'='"
                         + INPUT_TABLE
-                        + "','sink.max-buffer-size'='1024"
+                        + "','sink.max-mutation-buffer-ops'='1024"
                         + "','sink.flush-interval'='1000ms"
                         + "','sink.operation-timeout'='500ms"
                         + "','sink.ignore-not-found'='true"

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactoryOptionsTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactoryOptionsTest.java
@@ -1,0 +1,91 @@
+/*
+ * Licensed to the Apache Software Foundation (ASF) under one or more
+ * contributor license agreements.  See the NOTICE file distributed with
+ * this work for additional information regarding copyright ownership.
+ * The ASF licenses this file to You under the Apache License, Version 2.0
+ * (the "License"); you may not use this file except in compliance with
+ * the License.  You may obtain a copy of the License at
+ *
+ *    http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+
+package org.apache.flink.connector.kudu.table;
+
+import org.apache.flink.configuration.Configuration;
+import org.apache.flink.connector.kudu.connector.KuduTableInfo;
+import org.apache.flink.connector.kudu.connector.writer.KuduWriterConfig;
+import org.apache.flink.table.api.DataTypes;
+import org.apache.flink.table.catalog.CatalogTable;
+import org.apache.flink.table.catalog.Column;
+import org.apache.flink.table.catalog.ObjectIdentifier;
+import org.apache.flink.table.catalog.ResolvedCatalogTable;
+import org.apache.flink.table.catalog.ResolvedSchema;
+import org.apache.flink.table.connector.sink.DynamicTableSink;
+import org.apache.flink.table.factories.FactoryUtil;
+
+import org.junit.jupiter.api.Test;
+
+import java.util.HashMap;
+import java.util.Map;
+
+import static org.junit.jupiter.api.Assertions.assertEquals;
+
+/** Tests for Kudu dynamic table sink options. */
+class KuduDynamicTableFactoryOptionsTest {
+
+    private static final String MASTERS = "localhost";
+    private static final String TABLE_NAME = "TestTable";
+    private static final ResolvedSchema SCHEMA =
+            ResolvedSchema.of(
+                    Column.physical("first", DataTypes.STRING()),
+                    Column.physical("second", DataTypes.STRING()));
+
+    @Test
+    void testMaxMutationBufferOpsOptionConfiguresSink() {
+        Map<String, String> properties = baseProperties();
+        properties.put("sink.max-mutation-buffer-ops", "123");
+
+        assertEquals(expectedSink(123), createSink(properties));
+    }
+
+    @Test
+    void testDeprecatedMaxBufferSizeOptionStillConfiguresSink() {
+        Map<String, String> properties = baseProperties();
+        properties.put("sink.max-buffer-size", "456");
+
+        assertEquals(expectedSink(456), createSink(properties));
+    }
+
+    private static Map<String, String> baseProperties() {
+        Map<String, String> properties = new HashMap<>();
+        properties.put("connector", "kudu");
+        properties.put("masters", MASTERS);
+        properties.put("table-name", TABLE_NAME);
+        return properties;
+    }
+
+    private static DynamicTableSink expectedSink(int maxMutationBufferOps) {
+        KuduWriterConfig.Builder builder =
+                KuduWriterConfig.Builder.setMasters(MASTERS)
+                        .setMaxMutationBufferOps(maxMutationBufferOps);
+        KuduTableInfo tableInfo = KuduTableInfo.forTable(TABLE_NAME);
+        return new KuduDynamicTableSink(builder, tableInfo, SCHEMA);
+    }
+
+    private static DynamicTableSink createSink(Map<String, String> properties) {
+        return FactoryUtil.createDynamicTableSink(
+                null,
+                ObjectIdentifier.of("kudu", "default", TABLE_NAME),
+                new ResolvedCatalogTable(CatalogTable.fromProperties(properties), SCHEMA),
+                properties,
+                new Configuration(),
+                Thread.currentThread().getContextClassLoader(),
+                false);
+    }
+}

--- a/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactoryTest.java
+++ b/flink-connector-kudu/src/test/java/org/apache/flink/connector/kudu/table/KuduDynamicTableFactoryTest.java
@@ -225,13 +225,13 @@ public class KuduDynamicTableFactoryTest extends KuduTestBase {
         properties.put("sink.ignore-duplicate", "true");
         properties.put("sink.flush-mode", "auto_flush_sync");
         properties.put("sink.flush-interval", "10000");
-        properties.put("sink.max-buffer-size", "10000");
+        properties.put("sink.max-mutation-buffer-ops", "10000");
 
         KuduWriterConfig.Builder builder =
                 KuduWriterConfig.Builder.setMasters(kuduMasters)
                         .setConsistency(SessionConfiguration.FlushMode.AUTO_FLUSH_SYNC)
                         .setFlushInterval(10000)
-                        .setMaxBufferSize(10000)
+                        .setMaxMutationBufferOps(10000)
                         .setIgnoreDuplicate(true)
                         .setIgnoreNotFound(true);
         KuduTableInfo kuduTableInfo = KuduTableInfo.forTable("TestTable12");


### PR DESCRIPTION
## Summary

- Rename the Kudu writer buffer configuration from `maxBufferSize` to `maxMutationBufferOps`.
- Add the new table option `sink.max-mutation-buffer-ops`.
- Preserve backward compatibility for the old Java API and the deprecated `sink.max-buffer-size` option.

## Root Cause

`KuduWriterConfig.maxBufferSize` and the table option `sink.max-buffer-size` describe the number of buffered mutation operations, not a byte size. This made the option name misleading compared with the underlying Kudu session setting.

## Changes

- Add `KuduWriterConfig#getMaxMutationBufferOps()` and `Builder#setMaxMutationBufferOps(int)`.
- Keep deprecated `getMaxBufferSize()` and `setMaxBufferSize(int)` delegating to the new API.
- Add `KuduDynamicTableOptions.MAX_MUTATION_BUFFER_OPS` for `sink.max-mutation-buffer-ops` with `sink.max-buffer-size` as a deprecated key.
- Update factory/writer wiring and existing Kudu table tests to use the new name.
- Add focused tests for both the new option/API and deprecated compatibility paths.

## Validation

- `mvn -pl flink-connector-kudu -Dtest=KuduWriterConfigTest,KuduDynamicTableFactoryOptionsTest -DfailIfNoTests=false test`
- `mvn -pl flink-connector-kudu -DskipTests test`

The Docker/Testcontainers-backed Kudu integration tests were not run locally because this environment does not provide a Docker socket.

## AI assistance disclosure

This PR was prepared with AI assistance and manually validated with the commands above.
